### PR TITLE
fix: при update userId и filmId просто игнорируются

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/service/ReviewService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/ReviewService.java
@@ -72,15 +72,11 @@ public class ReviewService {
     }
 
     public Review updateReview(Review review) {
-        Long reviewId = review.getReviewId();
-        Long userId = review.getUserId();
-        checkReviewId(reviewId);
-        checkFilmId(review.getFilmId());
-        checkUserId(userId);
-        reviewStorage.updateReview(review);
-        log.info("Обновлен отзыв c id = {}", reviewId);
-        feedStorage.addFeed(reviewId, userId, EventType.REVIEW, Operation.UPDATE);
-        return getReviewById(reviewId);
+        checkReviewId(review.getReviewId());
+        review = reviewStorage.updateReview(review);
+        log.info("Обновлен отзыв c id = {}", review.getReviewId());
+        feedStorage.addFeed(review.getReviewId(), review.getUserId(), EventType.REVIEW, Operation.UPDATE);
+        return review;
     }
 
     public void deleteReview(Long reviewId) {

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/review/ReviewDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/review/ReviewDbStorage.java
@@ -77,14 +77,12 @@ public class ReviewDbStorage implements ReviewStorage {
     @Override
     public Review updateReview(Review review) {
         String sqlQuery = "UPDATE REVIEWS "
-                + "SET CONTENT = ?, FILM_ID = ?, USER_ID = ?, IS_POSITIVE = ? WHERE FILM_ID = ?";
+                + "SET CONTENT = ?, IS_POSITIVE = ? WHERE FILM_ID = ?";
         if (jdbcTemplate.update(sqlQuery,
                 review.getContent(),
-                review.getFilmId(),
-                review.getUserId(),
                 review.getIsPositive(),
                 review.getReviewId()) != 0) {
-            return review;
+            return getReview(review.getReviewId());
         } else {
             return null;
         }


### PR DESCRIPTION
Заказчику не нужна возможность изменять пользователя и фильм отзыва. При выполнении запроса переданные userId и filmId просто игнорируются.